### PR TITLE
Low Level API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,22 +6,7 @@
     },
 
     "rust-analyzer.cargo.features": [
-        "esp32c6",
+        "esp32","low-level"
     ],
-    "rust-analyzer.cargo.target": "riscv32imac-unknown-none-elf",
-
-    "rust-analyzer.checkOnSave.allTargets": false,
-    "rust-analyzer.checkOnSave.overrideCommand": [
-        "cargo",
-        "check",
-        "-Z", 
-        "build-std=core",
-        "--features",
-        "esp32c6",
-        "--target",
-        "riscv32imac-unknown-none-elf",
-        "--message-format", 
-        "json",
-        "--examples"
-    ],    
+    "rust-analyzer.cargo.target": "xtensa-esp32-none-elf",
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,12 +58,14 @@ name              = "low_level"
 required-features = ["low-level"]
 
 [features]
+default = ["critical-section"]
 critical-section = ["dep:critical-section"]
 esp32c2 = []
 esp32c3 = []
 esp32c6 = []
-esp32 = ["critical-section"]
+esp32   = []
 esp32s2 = []
 esp32s3 = []
 
+# this feature is reserved for very specific use-cases - usually you don't want to use this!
 low-level = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,10 @@ esp32s3-hal = { version = "0.7.0" }
 esp-println = { version = "0.4.0", features = [ "esp32s3" ] }
 esp-backtrace = { version = "0.6.0", features = [ "esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 
+[[example]]
+name              = "low_level"
+required-features = ["low-level"]
+
 [features]
 critical-section = ["dep:critical-section"]
 esp32c2 = []
@@ -61,3 +65,5 @@ esp32c6 = []
 esp32 = ["critical-section"]
 esp32s2 = []
 esp32s3 = []
+
+low-level = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ categories = [
 
 [dependencies]
 embedded-storage = "0.3.0"
+critical-section = { version =  "1.0.1", optional = true }
 
 # specifying dev dependencies by target is less than ideal - however we cannot have feature gated dev-dependencies
 
@@ -53,9 +54,10 @@ esp-println = { version = "0.4.0", features = [ "esp32s3" ] }
 esp-backtrace = { version = "0.6.0", features = [ "esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 
 [features]
+critical-section = ["dep:critical-section"]
 esp32c2 = []
 esp32c3 = []
 esp32c6 = []
-esp32 = []
+esp32 = ["critical-section"]
 esp32s2 = []
 esp32s3 = []

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ To make it work also for debug builds add this to your `Cargo.toml`
 opt-level = 3
 ```
 
-Make sure to call the functions in an interrupt-free context. On ESP32 there is the default-feauture `critical-section` which will ensure this.
-
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To make it work also for debug builds add this to your `Cargo.toml`
 opt-level = 3
 ```
 
-Make sure to call the functions in an interrupt-free context.
+Make sure to call the functions in an interrupt-free context. On ESP32 there is the default-feauture `critical-section` which will ensure this.
 
 ## License
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -23,11 +23,6 @@ use esp32c6_hal as hal;
 use hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
 
 use esp_storage::FlashStorage;
-#[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
-use xtensa_lx_rt::entry;
-
-#[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
-use riscv_rt::entry;
 
 use esp_backtrace as _;
 use esp_println::println;

--- a/examples/low_level.rs
+++ b/examples/low_level.rs
@@ -1,3 +1,8 @@
+//! This shows usage of the underlying low-level API
+//!
+//! Using this API is generally discouraged and reserved to a few very special use-cases.
+//!
+
 #![no_std]
 #![no_main]
 

--- a/examples/low_level.rs
+++ b/examples/low_level.rs
@@ -1,0 +1,136 @@
+#![no_std]
+#![no_main]
+
+#[cfg(feature = "esp32")]
+use esp32_hal as hal;
+
+#[cfg(feature = "esp32s2")]
+use esp32s2_hal as hal;
+
+#[cfg(feature = "esp32s3")]
+use esp32s3_hal as hal;
+
+#[cfg(feature = "esp32c3")]
+use esp32c3_hal as hal;
+
+#[cfg(feature = "esp32c2")]
+use esp32c2_hal as hal;
+
+#[cfg(feature = "esp32c6")]
+use esp32c6_hal as hal;
+
+use hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
+
+use esp_backtrace as _;
+use esp_println::println;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+
+    #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
+    {
+        #[cfg(feature = "esp32")]
+        let system = peripherals.DPORT.split();
+        #[cfg(not(feature = "esp32"))]
+        let system = peripherals.SYSTEM.split();
+
+        let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+        let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+        let mut wdt = timer_group0.wdt;
+        let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+
+        // Disable MWDT and RWDT (Watchdog) flash boot protection
+        wdt.disable();
+        rtc.rwdt.disable();
+    }
+
+    #[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
+    {
+        let system = peripherals.SYSTEM.split();
+        let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+        let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+        let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+        let mut wdt0 = timer_group0.wdt;
+
+        #[cfg(not(feature = "esp32c2"))]
+        let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+        #[cfg(not(feature = "esp32c2"))]
+        let mut wdt1 = timer_group1.wdt;
+
+        rtc.swd.disable();
+        rtc.rwdt.disable();
+        wdt0.disable();
+        #[cfg(not(feature = "esp32c2"))]
+        wdt1.disable();
+    }
+
+    #[cfg(any(feature = "esp32c6"))]
+    {
+        let system = peripherals.PCR.split();
+        let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+        let mut rtc = Rtc::new(peripherals.LP_CLKRST);
+        let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+        let mut wdt0 = timer_group0.wdt;
+
+        #[cfg(not(feature = "esp32c2"))]
+        let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+        #[cfg(not(feature = "esp32c2"))]
+        let mut wdt1 = timer_group1.wdt;
+
+        rtc.swd.disable();
+        rtc.rwdt.disable();
+        wdt0.disable();
+        #[cfg(not(feature = "esp32c2"))]
+        wdt1.disable();
+    }
+
+    let mut bytes = [0u8; 48];
+    let flash_addr = 0x9000;
+
+    unsafe {
+        esp_storage::ll::spiflash_read(
+            flash_addr,
+            bytes.as_mut_ptr() as *mut u32,
+            bytes.len() as u32,
+        )
+    }
+    .unwrap();
+
+    println!("Read from {:x}:  {:02x?}", flash_addr, &bytes[..48]);
+
+    bytes[0x00] = bytes[0x00].wrapping_add(1);
+    bytes[0x01] = bytes[0x01].wrapping_add(2);
+    bytes[0x02] = bytes[0x02].wrapping_add(3);
+    bytes[0x03] = bytes[0x03].wrapping_add(4);
+    bytes[0x04] = bytes[0x04].wrapping_add(1);
+    bytes[0x05] = bytes[0x05].wrapping_add(2);
+    bytes[0x06] = bytes[0x06].wrapping_add(3);
+    bytes[0x07] = bytes[0x07].wrapping_add(4);
+
+    unsafe { esp_storage::ll::spiflash_unlock() }.unwrap();
+
+    unsafe { esp_storage::ll::spiflash_erase_sector(flash_addr / 4096) }.unwrap();
+
+    unsafe {
+        esp_storage::ll::spiflash_write(flash_addr, bytes.as_ptr() as *const u8, bytes.len() as u32)
+    }
+    .unwrap();
+    println!("Written to {:x}: {:02x?}", flash_addr, &bytes[..48]);
+
+    let mut reread_bytes = [0u8; 48];
+    unsafe {
+        esp_storage::ll::spiflash_read(
+            flash_addr,
+            reread_bytes.as_mut_ptr() as *mut u32,
+            reread_bytes.len() as u32,
+        )
+    }
+    .unwrap();
+    println!("Read from {:x}:  {:02x?}", flash_addr, &reread_bytes[..48]);
+
+    loop {}
+}

--- a/src/esp32.rs
+++ b/src/esp32.rs
@@ -110,62 +110,68 @@ pub struct EspRomSpiflashChipT {
 #[inline(never)]
 #[link_section = ".rwtext"]
 pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    spiflash_wait_for_ready();
-    unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_READ);
-        esp_rom_spiflash_read(src_addr, data, len)
-    }
+    with(|| {
+        spiflash_wait_for_ready();
+        unsafe {
+            let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
+                core::mem::transmute(ESP_ROM_SPIFLASH_READ);
+            esp_rom_spiflash_read(src_addr, data, len)
+        }
+    })
 }
 
 #[inline(never)]
 #[link_section = ".rwtext"]
 pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    let res = unsafe {
-        let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
-        esp_rom_spiflash_erase_sector(sector_number)
-    };
+    with(|| {
+        let res = unsafe {
+            let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
+                core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
+            esp_rom_spiflash_erase_sector(sector_number)
+        };
 
-    if res != 0 {
-        end();
-    }
-    res
+        if res != 0 {
+            end();
+        }
+        res
+    })
 }
 
 #[inline(never)]
 #[link_section = ".rwtext"]
 pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u8, len: u32) -> i32 {
-    begin();
+    with(|| {
+        begin();
 
-    for block in (0..len).step_by(32 * 4) {
-        spi_write_enable();
+        for block in (0..len).step_by(32 * 4) {
+            spi_write_enable();
 
-        let block_len = if (len - block) % (32 * 4) == 0 {
-            32 * 4
-        } else {
-            (len - block) % (32 * 4)
-        };
-        write_register(
-            PERIPHS_SPI_FLASH_ADDR,
-            (dest_addr + block) | block_len << 24,
-        );
+            let block_len = if (len - block) % (32 * 4) == 0 {
+                32 * 4
+            } else {
+                (len - block) % (32 * 4)
+            };
+            write_register(
+                PERIPHS_SPI_FLASH_ADDR,
+                (dest_addr + block) | block_len << 24,
+            );
 
-        let data_ptr = unsafe { data.offset(block as isize) as *const u32 };
-        for i in 0..block_len / 4 {
-            write_register(PERIPHS_SPI_FLASH_C0 + 4 * i, unsafe {
-                data_ptr.offset(i as isize).read_volatile()
-            });
+            let data_ptr = unsafe { data.offset(block as isize) as *const u32 };
+            for i in 0..block_len / 4 {
+                write_register(PERIPHS_SPI_FLASH_C0 + 4 * i, unsafe {
+                    data_ptr.offset(i as isize).read_volatile()
+                });
+            }
+
+            write_register(SPI_CMD_REG, 1 << 25); // FLASH PP
+            while read_register(SPI_CMD_REG) != 0 { /* wait */ }
+
+            wait_for_ready();
         }
 
-        write_register(SPI_CMD_REG, 1 << 25); // FLASH PP
-        while read_register(SPI_CMD_REG) != 0 { /* wait */ }
-
-        wait_for_ready();
-    }
-
-    end();
-    0
+        end();
+        0
+    })
 }
 
 #[inline(always)]
@@ -218,36 +224,47 @@ fn spi_write_enable() {
 #[inline(never)]
 #[link_section = ".rwtext"]
 pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    begin();
-    let flashchip = FLASH_CHIP_ADDR as *const EspRomSpiflashChipT;
-    let mut status: u32 = 0;
+    with(|| {
+        begin();
+        let flashchip = FLASH_CHIP_ADDR as *const EspRomSpiflashChipT;
+        let mut status: u32 = 0;
 
-    spiflash_wait_for_ready(); /* ROM SPI_read_status_high() doesn't wait for this */
-    if spi_read_status_high(flashchip, &mut status) != 0 {
-        return -1;
-    }
+        spiflash_wait_for_ready(); /* ROM SPI_read_status_high() doesn't wait for this */
+        if spi_read_status_high(flashchip, &mut status) != 0 {
+            return -1;
+        }
 
-    let new_status = status & STATUS_QIE_BIT;
+        let new_status = status & STATUS_QIE_BIT;
 
-    // two bytes data will be written to status register when it is set
-    // bit 12 = WAIT_FLASH_IDLE_EN RW wait flash idle when program flash or erase flash. 1: enable 0: disable.
-    write_register(
-        SPI_CTRL_REG,
-        read_register(SPI_CTRL_REG) | SPI_WRSR_2B | (1 << 12),
-    );
+        // two bytes data will be written to status register when it is set
+        // bit 12 = WAIT_FLASH_IDLE_EN RW wait flash idle when program flash or erase flash. 1: enable 0: disable.
+        write_register(
+            SPI_CTRL_REG,
+            read_register(SPI_CTRL_REG) | SPI_WRSR_2B | (1 << 12),
+        );
 
-    spi_write_enable();
-    if spi_write_status(flashchip, new_status) != 0 {
+        spi_write_enable();
+        if spi_write_status(flashchip, new_status) != 0 {
+            end();
+            return -1;
+        }
+
+        // WEL bit should be cleared after operations regardless of writing succeed or not.
+        //  spiflash_wait_for_ready();
+        write_register(SPI_CMD_REG, SPI_FLASH_WRDI);
+        while read_register(SPI_CMD_REG) != 0 {}
+        //  spiflash_wait_for_ready();
+
         end();
-        return -1;
-    }
+        0
+    })
+}
 
-    // WEL bit should be cleared after operations regardless of writing succeed or not.
-    //  spiflash_wait_for_ready();
-    write_register(SPI_CMD_REG, SPI_FLASH_WRDI);
-    while read_register(SPI_CMD_REG) != 0 {}
-    //  spiflash_wait_for_ready();
+#[inline(always)]
+fn with<R>(f: impl FnOnce() -> R) -> R {
+    #[cfg(feature = "critical-section")]
+    return critical_section::with(|_| f());
 
-    end();
-    0
+    #[cfg(not(feature = "critical-section"))]
+    f()
 }

--- a/src/esp32c2.rs
+++ b/src/esp32c2.rs
@@ -1,36 +1,38 @@
+use crate::maybe_with_critical_section;
+
 const ESP_ROM_SPIFLASH_READ: u32 = 0x4000013c;
 const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000140;
 const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x40000130;
 const ESP_ROM_SPIFLASH_WRITE: u32 = 0x40000138;
 
 pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_READ);
         esp_rom_spiflash_read(src_addr, data, len)
-    }
+    })
 }
 
 pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_unlock: unsafe extern "C" fn() -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_UNLOCK);
         esp_rom_spiflash_unlock()
-    }
+    })
 }
 
 pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
         esp_rom_spiflash_erase_sector(sector_number)
-    }
+    })
 }
 
 pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u8, len: u32) -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_write: unsafe extern "C" fn(u32, *const u8, u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_WRITE);
         esp_rom_spiflash_write(dest_addr, data, len)
-    }
+    })
 }

--- a/src/esp32c3.rs
+++ b/src/esp32c3.rs
@@ -1,36 +1,38 @@
+use crate::maybe_with_critical_section;
+
 const ESP_ROM_SPIFLASH_READ: u32 = 0x40000130;
 const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000140;
 const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x40000128;
 const ESP_ROM_SPIFLASH_WRITE: u32 = 0x4000012c;
 
 pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_READ);
         esp_rom_spiflash_read(src_addr, data, len)
-    }
+    })
 }
 
 pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_unlock: unsafe extern "C" fn() -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_UNLOCK);
         esp_rom_spiflash_unlock()
-    }
+    })
 }
 
 pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
         esp_rom_spiflash_erase_sector(sector_number)
-    }
+    })
 }
 
 pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u8, len: u32) -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_write: unsafe extern "C" fn(u32, *const u8, u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_WRITE);
         esp_rom_spiflash_write(dest_addr, data, len)
-    }
+    })
 }

--- a/src/esp32c6.rs
+++ b/src/esp32c6.rs
@@ -1,36 +1,38 @@
+use crate::maybe_with_critical_section;
+
 const ESP_ROM_SPIFLASH_READ: u32 = 0x40000150;
 const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000154;
 const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x40000144;
 const ESP_ROM_SPIFLASH_WRITE: u32 = 0x4000014c;
 
 pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_READ);
         esp_rom_spiflash_read(src_addr, data, len)
-    }
+    })
 }
 
 pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_unlock: unsafe extern "C" fn() -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_UNLOCK);
         esp_rom_spiflash_unlock()
-    }
+    })
 }
 
 pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
         esp_rom_spiflash_erase_sector(sector_number)
-    }
+    })
 }
 
 pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u8, len: u32) -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_write: unsafe extern "C" fn(u32, *const u8, u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_WRITE);
         esp_rom_spiflash_write(dest_addr, data, len)
-    }
+    })
 }

--- a/src/esp32s2.rs
+++ b/src/esp32s2.rs
@@ -1,36 +1,38 @@
+use crate::maybe_with_critical_section;
+
 const ESP_ROM_SPIFLASH_READ: u32 = 0x4001728c;
 const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40016e88;
 const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x4001716c;
 const ESP_ROM_SPIFLASH_WRITE: u32 = 0x400171cc;
 
 pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_READ);
         esp_rom_spiflash_read(src_addr, data, len)
-    }
+    })
 }
 
 pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_unlock: unsafe extern "C" fn() -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_UNLOCK);
         esp_rom_spiflash_unlock()
-    }
+    })
 }
 
 pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
         esp_rom_spiflash_erase_sector(sector_number)
-    }
+    })
 }
 
 pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u8, len: u32) -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_write: unsafe extern "C" fn(u32, *const u8, u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_WRITE);
         esp_rom_spiflash_write(dest_addr, data, len)
-    }
+    })
 }

--- a/src/esp32s3.rs
+++ b/src/esp32s3.rs
@@ -1,3 +1,5 @@
+use crate::maybe_with_critical_section;
+
 const ESP_ROM_SPIFLASH_READ: u32 = 0x40000a20;
 const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000a2c;
 const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x400009fc;
@@ -6,39 +8,39 @@ const ESP_ROM_SPIFLASH_WRITE: u32 = 0x40000a14;
 #[inline(always)]
 #[link_section = ".rwtext"]
 pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_READ);
         esp_rom_spiflash_read(src_addr, data, len)
-    }
+    })
 }
 
 #[inline(always)]
 #[link_section = ".rwtext"]
 pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_unlock: unsafe extern "C" fn() -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_UNLOCK);
         esp_rom_spiflash_unlock()
-    }
+    })
 }
 
 #[inline(always)]
 #[link_section = ".rwtext"]
 pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
         esp_rom_spiflash_erase_sector(sector_number)
-    }
+    })
 }
 
 #[inline(always)]
 #[link_section = ".rwtext"]
 pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u8, len: u32) -> i32 {
-    unsafe {
+    maybe_with_critical_section(|| unsafe {
         let esp_rom_spiflash_write: unsafe extern "C" fn(u32, *const u8, u32) -> i32 =
             core::mem::transmute(ESP_ROM_SPIFLASH_WRITE);
         esp_rom_spiflash_write(dest_addr, data, len)
-    }
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,16 @@ impl Storage for FlashStorage {
     }
 }
 
+#[inline(always)]
+#[link_section = ".rwtext"]
+fn maybe_with_critical_section<R>(f: impl FnOnce() -> R) -> R {
+    #[cfg(feature = "critical-section")]
+    return critical_section::with(|_| f());
+
+    #[cfg(not(feature = "critical-section"))]
+    f()
+}
+
 #[cfg(feature = "low-level")]
 /// Low-level API
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,3 +171,39 @@ impl Storage for FlashStorage {
         }
     }
 }
+
+#[cfg(feature = "low-level")]
+/// Low-level API
+///
+/// This gives you access to the underlying low level functionality.
+/// These operate on raw pointers and all functions here are unsafe.
+/// No pre-conditions are checked by any of these functions.
+pub mod ll {
+    pub unsafe fn spiflash_read(src_addr: u32, data: *const u32, len: u32) -> Result<(), i32> {
+        match crate::chip_specific::esp_rom_spiflash_read(src_addr, data, len) {
+            0 => Ok(()),
+            value => Err(value),
+        }
+    }
+
+    pub unsafe fn spiflash_unlock() -> Result<(), i32> {
+        match crate::chip_specific::esp_rom_spiflash_unlock() {
+            0 => Ok(()),
+            value => Err(value),
+        }
+    }
+
+    pub unsafe fn spiflash_erase_sector(sector_number: u32) -> Result<(), i32> {
+        match crate::chip_specific::esp_rom_spiflash_erase_sector(sector_number) {
+            0 => Ok(()),
+            value => Err(value),
+        }
+    }
+
+    pub unsafe fn spiflash_write(dest_addr: u32, data: *const u8, len: u32) -> Result<(), i32> {
+        match crate::chip_specific::esp_rom_spiflash_write(dest_addr, data, len) {
+            0 => Ok(()),
+            value => Err(value),
+        }
+    }
+}


### PR DESCRIPTION
This adds a feature `low-level` which makes the low-level functionality available as unsafe functions - it's not advertised in the README since it's reserved for some rare use-cases (e.g., the NVS crate a community member is working on)

Additionally, this adds a ESP32-default feature `critical-section`. It's not useful for other chips and a no-op for them.

Closes #7
Closes #9

Best thing: This finally fixes the ESP32 write-flash function in a reasonable way (i.e. it now also works without erasing the page immediately before writing)
