### PR TITLE
Convert function address constants to function pointers

### DIFF
--- a/src/esp32c2.rs
+++ b/src/esp32c2.rs
@@ -1,38 +1,25 @@
 use crate::maybe_with_critical_section;
+use core::mem::transmute;
 
-const ESP_ROM_SPIFLASH_READ: u32 = 0x4000013c;
-const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000140;
-const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x40000130;
-const ESP_ROM_SPIFLASH_WRITE: u32 = 0x40000138;
+const ESP_ROM_SPIFLASH_READ: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
+    transmute(0x4000013c);
+const ESP_ROM_SPIFLASH_UNLOCK: unsafe extern "C" fn() -> i32 = transmute(0x40000140);
+const ESP_ROM_SPIFLASH_ERASE_SECTOR: unsafe extern "C" fn(u32) -> i32 = transmute(0x40000130);
+const ESP_ROM_SPIFLASH_WRITE: unsafe extern "C" fn(u32, *const u8, u32) -> i32 =
+    transmute(0x40000138);
 
 pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_READ);
-        esp_rom_spiflash_read(src_addr, data, len)
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_READ(src_addr, data, len) })
 }
 
 pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_unlock: unsafe extern "C" fn() -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_UNLOCK);
-        esp_rom_spiflash_unlock()
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_UNLOCK() })
 }
 
 pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
-        esp_rom_spiflash_erase_sector(sector_number)
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_ERASE_SECTOR(sector_number) })
 }
 
 pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u8, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_write: unsafe extern "C" fn(u32, *const u8, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_WRITE);
-        esp_rom_spiflash_write(dest_addr, data, len)
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_WRITE(dest_addr, data, len) })
 }

--- a/src/esp32c3.rs
+++ b/src/esp32c3.rs
@@ -1,38 +1,25 @@
 use crate::maybe_with_critical_section;
+use core::mem::transmute;
 
-const ESP_ROM_SPIFLASH_READ: u32 = 0x40000130;
-const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000140;
-const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x40000128;
-const ESP_ROM_SPIFLASH_WRITE: u32 = 0x4000012c;
+const ESP_ROM_SPIFLASH_READ: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
+    transmute(0x40000130);
+const ESP_ROM_SPIFLASH_UNLOCK: unsafe extern "C" fn() -> i32 = transmute(0x40000140);
+const ESP_ROM_SPIFLASH_ERASE_SECTOR: unsafe extern "C" fn(u32) -> i32 = transmute(0x40000128);
+const ESP_ROM_SPIFLASH_WRITE: unsafe extern "C" fn(u32, *const u8, u32) -> i32 =
+    transmute(0x4000012c);
 
 pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_READ);
-        esp_rom_spiflash_read(src_addr, data, len)
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_READ(src_addr, data, len) })
 }
 
 pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_unlock: unsafe extern "C" fn() -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_UNLOCK);
-        esp_rom_spiflash_unlock()
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_UNLOCK() })
 }
 
 pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
-        esp_rom_spiflash_erase_sector(sector_number)
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_ERASE_SECTOR(sector_number) })
 }
 
 pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u8, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_write: unsafe extern "C" fn(u32, *const u8, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_WRITE);
-        esp_rom_spiflash_write(dest_addr, data, len)
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_WRITE(dest_addr, data, len) })
 }

--- a/src/esp32c6.rs
+++ b/src/esp32c6.rs
@@ -1,38 +1,25 @@
 use crate::maybe_with_critical_section;
+use core::mem::transmute;
 
-const ESP_ROM_SPIFLASH_READ: u32 = 0x40000150;
-const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000154;
-const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x40000144;
-const ESP_ROM_SPIFLASH_WRITE: u32 = 0x4000014c;
+const ESP_ROM_SPIFLASH_READ: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
+    transmute(0x40000150);
+const ESP_ROM_SPIFLASH_UNLOCK: unsafe extern "C" fn() -> i32 = transmute(0x40000154);
+const ESP_ROM_SPIFLASH_ERASE_SECTOR: unsafe extern "C" fn(u32) -> i32 = transmute(0x40000144);
+const ESP_ROM_SPIFLASH_WRITE: unsafe extern "C" fn(u32, *const u8, u32) -> i32 =
+    transmute(0x4000014c);
 
 pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_READ);
-        esp_rom_spiflash_read(src_addr, data, len)
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_READ(src_addr, data, len) })
 }
 
 pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_unlock: unsafe extern "C" fn() -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_UNLOCK);
-        esp_rom_spiflash_unlock()
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_UNLOCK() })
 }
 
 pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
-        esp_rom_spiflash_erase_sector(sector_number)
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_ERASE_SECTOR(sector_number) })
 }
 
 pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u8, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_write: unsafe extern "C" fn(u32, *const u8, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_WRITE);
-        esp_rom_spiflash_write(dest_addr, data, len)
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_WRITE(dest_addr, data, len) })
 }

--- a/src/esp32s2.rs
+++ b/src/esp32s2.rs
@@ -1,38 +1,25 @@
 use crate::maybe_with_critical_section;
+use core::mem::transmute;
 
-const ESP_ROM_SPIFLASH_READ: u32 = 0x4001728c;
-const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40016e88;
-const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x4001716c;
-const ESP_ROM_SPIFLASH_WRITE: u32 = 0x400171cc;
+const ESP_ROM_SPIFLASH_READ: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
+    transmute(0x4001728c);
+const ESP_ROM_SPIFLASH_UNLOCK: unsafe extern "C" fn() -> i32 = transmute(0x40016e88);
+const ESP_ROM_SPIFLASH_ERASE_SECTOR: unsafe extern "C" fn(u32) -> i32 = transmute(0x4001716c);
+const ESP_ROM_SPIFLASH_WRITE: unsafe extern "C" fn(u32, *const u8, u32) -> i32 =
+    transmute(0x400171cc);
 
 pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_READ);
-        esp_rom_spiflash_read(src_addr, data, len)
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_READ(src_addr, data, len) })
 }
 
 pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_unlock: unsafe extern "C" fn() -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_UNLOCK);
-        esp_rom_spiflash_unlock()
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_UNLOCK() })
 }
 
 pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
-        esp_rom_spiflash_erase_sector(sector_number)
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_ERASE_SECTOR(sector_number) })
 }
 
 pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u8, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_write: unsafe extern "C" fn(u32, *const u8, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_WRITE);
-        esp_rom_spiflash_write(dest_addr, data, len)
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_WRITE(dest_addr, data, len) })
 }

--- a/src/esp32s3.rs
+++ b/src/esp32s3.rs
@@ -1,46 +1,33 @@
 use crate::maybe_with_critical_section;
+use core::mem::transmute;
 
-const ESP_ROM_SPIFLASH_READ: u32 = 0x40000a20;
-const ESP_ROM_SPIFLASH_UNLOCK: u32 = 0x40000a2c;
-const ESP_ROM_SPIFLASH_ERASE_SECTOR: u32 = 0x400009fc;
-const ESP_ROM_SPIFLASH_WRITE: u32 = 0x40000a14;
+const ESP_ROM_SPIFLASH_READ: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
+    transmute(0x40000a20);
+const ESP_ROM_SPIFLASH_UNLOCK: unsafe extern "C" fn() -> i32 = transmute(0x40000a2c);
+const ESP_ROM_SPIFLASH_ERASE_SECTOR: unsafe extern "C" fn(u32) -> i32 = transmute(0x400009fc);
+const ESP_ROM_SPIFLASH_WRITE: unsafe extern "C" fn(u32, *const u8, u32) -> i32 =
+    transmute(0x40000a14);
 
 #[inline(always)]
 #[link_section = ".rwtext"]
 pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_read: unsafe extern "C" fn(u32, *const u32, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_READ);
-        esp_rom_spiflash_read(src_addr, data, len)
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_READ(src_addr, data, len) })
 }
 
 #[inline(always)]
 #[link_section = ".rwtext"]
 pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_unlock: unsafe extern "C" fn() -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_UNLOCK);
-        esp_rom_spiflash_unlock()
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_UNLOCK() })
 }
 
 #[inline(always)]
 #[link_section = ".rwtext"]
 pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_erase_sector: unsafe extern "C" fn(u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_ERASE_SECTOR);
-        esp_rom_spiflash_erase_sector(sector_number)
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_ERASE_SECTOR(sector_number) })
 }
 
 #[inline(always)]
 #[link_section = ".rwtext"]
 pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u8, len: u32) -> i32 {
-    maybe_with_critical_section(|| unsafe {
-        let esp_rom_spiflash_write: unsafe extern "C" fn(u32, *const u8, u32) -> i32 =
-            core::mem::transmute(ESP_ROM_SPIFLASH_WRITE);
-        esp_rom_spiflash_write(dest_addr, data, len)
-    })
+    maybe_with_critical_section(|| unsafe { ESP_ROM_SPIFLASH_WRITE(dest_addr, data, len) })
 }


### PR DESCRIPTION
Because `core::mem::transmute` is const fn it is preferred create constant function pointers instead of runtime conversion.