### PR TITLE
Add stub chip specific implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,17 @@ use embedded_storage::{ReadStorage, Storage};
 #[cfg_attr(feature = "esp32", path = "esp32.rs")]
 #[cfg_attr(feature = "esp32s2", path = "esp32s2.rs")]
 #[cfg_attr(feature = "esp32s3", path = "esp32s3.rs")]
+#[cfg_attr(
+    not(any(
+        feature = "esp32c2",
+        feature = "esp32c3",
+        feature = "esp32c6",
+        feature = "esp32",
+        feature = "esp32s2",
+        feature = "esp32s3"
+    )),
+    path = "stub.rs"
+)]
 mod chip_specific;
 
 const FLASH_SECTOR_SIZE: u32 = 4096;

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -1,0 +1,20 @@
+use crate::maybe_with_critical_section;
+
+#[cfg(not(doc))]
+compile_error!("Select a target using feature: esp32c2, esp32c3, esp32c6, esp32, esp32s2, esp32s3");
+
+pub(crate) fn esp_rom_spiflash_read(_src_addr: u32, _data: *const u32, _len: u32) -> i32 {
+    maybe_with_critical_section(|| unimplemented!())
+}
+
+pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
+    maybe_with_critical_section(|| unimplemented!())
+}
+
+pub(crate) fn esp_rom_spiflash_erase_sector(_sector_number: u32) -> i32 {
+    maybe_with_critical_section(|| unimplemented!())
+}
+
+pub(crate) fn esp_rom_spiflash_write(_dest_addr: u32, _data: *const u8, _len: u32) -> i32 {
+    maybe_with_critical_section(|| unimplemented!())
+}


### PR DESCRIPTION
If no target chip feature selected it shows corresponding error. Like the following:

```
error: Select a target using feature: esp32c2, esp32c3, esp32c6, esp32, esp32s2, esp32s3
 --> src/stub.rs:4:1
  |
4 | compile_error!("Select a target using feature: esp32c2, esp32c3, esp32c6, esp32, esp32s2, esp32s3");
  |

error: could not compile `esp-storage` due to previous error
```

Also it provides stub implementation to allow generate documentation even if no target chip is set.