### PR TITLE
Nor flash rework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,14 @@ name              = "low_level"
 required-features = ["low-level"]
 
 [features]
-default = ["critical-section"]
+default = ["critical-section", "storage"]
 critical-section = ["dep:critical-section"]
+# ReadStorage/Storage traits
+storage = []
+# ReadNorFlash/NorFlash traits
+nor-flash = []
+# Bytewise read emulation
+bytewise-read = []
 esp32c2 = []
 esp32c3 = []
 esp32c6 = []
@@ -76,6 +82,8 @@ esp32h2 = []
 esp32   = []
 esp32s2 = []
 esp32s3 = []
+# Enable flash emulation to run tests
+emulation = []
 
 # this feature is reserved for very specific use-cases - usually you don't want to use this!
 low-level = []

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,157 @@
+use crate::chip_specific;
+use core::ops::{Deref, DerefMut};
+
+#[repr(align(4))]
+pub struct FlashSectorBuffer {
+    data: [u8; FlashStorage::SECTOR_SIZE as usize],
+}
+
+impl Deref for FlashSectorBuffer {
+    type Target = [u8; FlashStorage::SECTOR_SIZE as usize];
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+impl DerefMut for FlashSectorBuffer {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
+    }
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum FlashStorageError {
+    IoError,
+    IoTimeout,
+    CantUnlock,
+    NotAligned,
+    OutOfBounds,
+    Other(i32),
+}
+
+#[inline(always)]
+pub fn check_rc(rc: i32) -> Result<(), FlashStorageError> {
+    match rc {
+        0 => Ok(()),
+        1 => Err(FlashStorageError::IoError),
+        2 => Err(FlashStorageError::IoTimeout),
+        _ => Err(FlashStorageError::Other(rc)),
+    }
+}
+
+#[derive(Debug)]
+pub struct FlashStorage {
+    pub(crate) capacity: usize,
+    unlocked: bool,
+}
+
+impl Default for FlashStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FlashStorage {
+    pub const WORD_SIZE: u32 = 4;
+    pub const SECTOR_SIZE: u32 = 4096;
+
+    pub fn new() -> FlashStorage {
+        let mut storage = FlashStorage {
+            capacity: 0,
+            unlocked: false,
+        };
+
+        #[cfg(not(any(feature = "esp32", feature = "esp32s2")))]
+        const ADDR: u32 = 0x0000;
+        #[cfg(any(feature = "esp32", feature = "esp32s2"))]
+        const ADDR: u32 = 0x1000;
+
+        let mut buffer = [0u8; 8];
+        storage.internal_read(ADDR, &mut buffer).ok();
+        let mb = match buffer[3] & 0xf0 {
+            0x00 => 1,
+            0x10 => 2,
+            0x20 => 4,
+            0x30 => 8,
+            0x40 => 16,
+            _ => 0,
+        };
+        storage.capacity = mb * 1024 * 1024;
+
+        storage
+    }
+
+    #[cfg(feature = "nor-flash")]
+    #[inline(always)]
+    pub(crate) fn check_alignment<const ALIGN: u32>(
+        &self,
+        offset: u32,
+        length: usize,
+    ) -> Result<(), FlashStorageError> {
+        let offset = offset as usize;
+        if offset % ALIGN as usize != 0 || length % ALIGN as usize != 0 {
+            return Err(FlashStorageError::NotAligned);
+        }
+        Ok(())
+    }
+
+    #[inline(always)]
+    pub(crate) fn check_bounds(&self, offset: u32, length: usize) -> Result<(), FlashStorageError> {
+        let offset = offset as usize;
+        if length > self.capacity || offset > self.capacity - length {
+            return Err(FlashStorageError::OutOfBounds);
+        }
+        Ok(())
+    }
+
+    #[inline(never)]
+    #[link_section = ".rwtext"]
+    pub(crate) fn internal_read(
+        &mut self,
+        offset: u32,
+        bytes: &mut [u8],
+    ) -> Result<(), FlashStorageError> {
+        check_rc(chip_specific::esp_rom_spiflash_read(
+            offset,
+            bytes.as_ptr() as *mut u32,
+            bytes.len() as u32,
+        ))
+    }
+
+    #[inline(always)]
+    fn unlock_once(&mut self) -> Result<(), FlashStorageError> {
+        if !self.unlocked {
+            if chip_specific::esp_rom_spiflash_unlock() != 0 {
+                return Err(FlashStorageError::CantUnlock);
+            }
+            self.unlocked = true;
+        }
+        Ok(())
+    }
+
+    #[inline(never)]
+    #[link_section = ".rwtext"]
+    pub(crate) fn internal_erase(&mut self, sector: u32) -> Result<(), FlashStorageError> {
+        self.unlock_once()?;
+
+        check_rc(chip_specific::esp_rom_spiflash_erase_sector(sector))
+    }
+
+    #[inline(never)]
+    #[link_section = ".rwtext"]
+    pub(crate) fn internal_write(
+        &mut self,
+        offset: u32,
+        bytes: &[u8],
+    ) -> Result<(), FlashStorageError> {
+        self.unlock_once()?;
+
+        check_rc(chip_specific::esp_rom_spiflash_write(
+            offset,
+            bytes.as_ptr() as *const u32,
+            bytes.len() as u32,
+        ))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
-#![no_std]
+#![cfg_attr(not(all(test, feature = "emulation")), no_std)]
 
-use embedded_storage::{ReadStorage, Storage};
-
+#[cfg(not(feature = "emulation"))]
 #[cfg_attr(feature = "esp32c2", path = "esp32c2.rs")]
 #[cfg_attr(feature = "esp32c3", path = "esp32c3.rs")]
 #[cfg_attr(feature = "esp32c6", path = "esp32c6.rs")]
@@ -23,186 +22,29 @@ use embedded_storage::{ReadStorage, Storage};
 )]
 mod chip_specific;
 
-const FLASH_SECTOR_SIZE: u32 = 4096;
+#[cfg(feature = "emulation")]
+#[path = "stub.rs"]
+mod chip_specific;
 
-#[derive(Debug)]
-pub enum FlashStorageError {
-    Other(i32),
-}
+#[cfg(any(feature = "storage", feature = "nor-flash"))]
+mod common;
 
-#[derive(Debug)]
-pub struct FlashStorage {
-    capacity: usize,
-    unlocked: bool,
-}
+#[cfg(any(feature = "storage", feature = "nor-flash"))]
+pub use common::{FlashStorage, FlashStorageError};
 
-impl FlashStorage {
-    pub fn new() -> FlashStorage {
-        let mut storage = FlashStorage {
-            capacity: 0,
-            unlocked: false,
-        };
+#[cfg(any(feature = "storage", feature = "nor-flash"))]
+use common::FlashSectorBuffer;
 
-        #[cfg(any(
-            feature = "esp32c3",
-            feature = "esp32s3",
-            feature = "esp32h2",
-            feature = "esp32c6",
-            feature = "esp32c2"
-        ))]
-        const ADDR: u32 = 0x0000;
-        #[cfg(not(any(
-            feature = "esp32c3",
-            feature = "esp32s3",
-            feature = "esp32h2",
-            feature = "esp32c6",
-            feature = "esp32c2"
-        )))]
-        const ADDR: u32 = 0x1000;
+#[cfg(feature = "storage")]
+mod storage;
 
-        let mut buffer = [0u8; 8];
-        storage.read(ADDR, &mut buffer).ok();
-        let mb = match buffer[3] & 0xf0 {
-            0x00 => 1,
-            0x10 => 2,
-            0x20 => 4,
-            0x30 => 8,
-            0x40 => 16,
-            _ => 0,
-        };
-        storage.capacity = mb * 1024 * 1024;
+#[cfg(feature = "nor-flash")]
+mod nor_flash;
 
-        storage
-    }
-}
+#[cfg(feature = "low-level")]
+pub mod ll;
 
-impl Default for FlashStorage {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[inline(never)]
-#[link_section = ".rwtext"]
-fn internal_read(offset: u32, bytes: &mut [u8]) -> Result<(), FlashStorageError> {
-    if bytes.len() % 4 != 0 {
-        return Err(FlashStorageError::Other(9999)); // TODO make this work - shouldn't be a requirement
-    }
-
-    let res = chip_specific::esp_rom_spiflash_read(
-        offset,
-        bytes.as_ptr() as *mut u8 as *mut u32,
-        bytes.len() as u32,
-    );
-
-    if res != 0 {
-        Err(FlashStorageError::Other(res))
-    } else {
-        Ok(())
-    }
-}
-
-#[inline(never)]
-#[link_section = ".rwtext"]
-fn internal_write(
-    storage: &mut FlashStorage,
-    offset: u32,
-    bytes: &[u8],
-) -> Result<(), FlashStorageError> {
-    if bytes.len() % 4 != 0 {
-        return Err(FlashStorageError::Other(9999)); // TODO make this work - shouldn't be a requirement
-    }
-
-    if !storage.unlocked {
-        if chip_specific::esp_rom_spiflash_unlock() != 0 {
-            return Err(FlashStorageError::Other(9998));
-        }
-        storage.unlocked = true;
-    }
-
-    let res = chip_specific::esp_rom_spiflash_erase_sector(offset / FLASH_SECTOR_SIZE);
-    if res != 0 {
-        return Err(FlashStorageError::Other(res));
-    }
-
-    let res = chip_specific::esp_rom_spiflash_write(
-        offset,
-        bytes.as_ptr() as *const u32,
-        bytes.len() as u32,
-    );
-
-    if res != 0 {
-        Err(FlashStorageError::Other(res))
-    } else {
-        Ok(())
-    }
-}
-
-impl ReadStorage for FlashStorage {
-    type Error = FlashStorageError;
-
-    fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
-        let mut sector_start = (offset / FLASH_SECTOR_SIZE) * FLASH_SECTOR_SIZE;
-        let mut data_offset = offset - sector_start;
-        let mut dst_offset = 0;
-        loop {
-            let mut sector_data = [0u8; FLASH_SECTOR_SIZE as usize];
-            internal_read(sector_start, &mut sector_data)?;
-
-            let len = u32::min(
-                FLASH_SECTOR_SIZE - data_offset,
-                (bytes.len() - dst_offset) as u32,
-            );
-
-            bytes[dst_offset..][..len as usize]
-                .copy_from_slice(&sector_data[data_offset as usize..][..len as usize]);
-
-            sector_start += FLASH_SECTOR_SIZE;
-            data_offset = 0;
-            dst_offset += len as usize;
-
-            if dst_offset >= bytes.len() {
-                break Ok(());
-            }
-        }
-    }
-
-    /// The SPI flash size is configured by writing a field in the software bootloader image header.
-    /// This is done during flashing in espflash / esptool.
-    fn capacity(&self) -> usize {
-        self.capacity
-    }
-}
-
-impl Storage for FlashStorage {
-    fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
-        let mut sector_start = (offset / FLASH_SECTOR_SIZE) * FLASH_SECTOR_SIZE;
-        let mut data_offset = offset - sector_start;
-        let mut dst_offset = 0;
-        loop {
-            let mut sector_data = [0u8; FLASH_SECTOR_SIZE as usize];
-            internal_read(sector_start, &mut sector_data)?;
-
-            let len = u32::min(
-                FLASH_SECTOR_SIZE - data_offset,
-                (bytes.len() - dst_offset) as u32,
-            );
-
-            sector_data[data_offset as usize..][..len as usize]
-                .copy_from_slice(&bytes[dst_offset..][..len as usize]);
-            internal_write(self, sector_start, &sector_data)?;
-
-            sector_start += FLASH_SECTOR_SIZE;
-            data_offset = 0;
-            dst_offset += len as usize;
-
-            if dst_offset >= bytes.len() {
-                break Ok(());
-            }
-        }
-    }
-}
-
+#[cfg(not(feature = "emulation"))]
 #[inline(always)]
 #[link_section = ".rwtext"]
 fn maybe_with_critical_section<R>(f: impl FnOnce() -> R) -> R {
@@ -213,5 +55,7 @@ fn maybe_with_critical_section<R>(f: impl FnOnce() -> R) -> R {
     f()
 }
 
-#[cfg(feature = "low-level")]
-pub mod ll;
+#[cfg(feature = "emulation")]
+fn maybe_with_critical_section<R>(f: impl FnOnce() -> R) -> R {
+    f()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,37 +214,4 @@ fn maybe_with_critical_section<R>(f: impl FnOnce() -> R) -> R {
 }
 
 #[cfg(feature = "low-level")]
-/// Low-level API
-///
-/// This gives you access to the underlying low level functionality.
-/// These operate on raw pointers and all functions here are unsafe.
-/// No pre-conditions are checked by any of these functions.
-pub mod ll {
-    pub unsafe fn spiflash_read(src_addr: u32, data: *const u32, len: u32) -> Result<(), i32> {
-        match crate::chip_specific::esp_rom_spiflash_read(src_addr, data, len) {
-            0 => Ok(()),
-            value => Err(value),
-        }
-    }
-
-    pub unsafe fn spiflash_unlock() -> Result<(), i32> {
-        match crate::chip_specific::esp_rom_spiflash_unlock() {
-            0 => Ok(()),
-            value => Err(value),
-        }
-    }
-
-    pub unsafe fn spiflash_erase_sector(sector_number: u32) -> Result<(), i32> {
-        match crate::chip_specific::esp_rom_spiflash_erase_sector(sector_number) {
-            0 => Ok(()),
-            value => Err(value),
-        }
-    }
-
-    pub unsafe fn spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> Result<(), i32> {
-        match crate::chip_specific::esp_rom_spiflash_write(dest_addr, data, len) {
-            0 => Ok(()),
-            value => Err(value),
-        }
-    }
-}
+pub mod ll;

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -1,0 +1,54 @@
+/// Low-level API
+///
+/// This gives you access to the underlying low level functionality.
+/// These operate on raw pointers and all functions here are unsafe.
+/// No pre-conditions are checked by any of these functions.
+use crate::chip_specific;
+
+/// Low-level SPI NOR Flash read
+///
+/// # Safety
+///
+/// The `src_addr` + `len` should not exceeds the size of flash.
+/// The `data` expected to points to word-aligned pre-allocated buffer with size greater or equals to `len`.
+pub unsafe fn spiflash_read(src_addr: u32, data: *mut u32, len: u32) -> Result<(), i32> {
+    match chip_specific::esp_rom_spiflash_read(src_addr, data, len) {
+        0 => Ok(()),
+        value => Err(value),
+    }
+}
+
+/// Low-level SPI NOR Flash unlock
+///
+/// # Safety
+pub unsafe fn spiflash_unlock() -> Result<(), i32> {
+    match chip_specific::esp_rom_spiflash_unlock() {
+        0 => Ok(()),
+        value => Err(value),
+    }
+}
+
+/// Low-level SPI NOR Flash erase
+///
+/// # Safety
+///
+/// The `sector_number` * sector_size should not exceeds the size of flash.
+pub unsafe fn spiflash_erase_sector(sector_number: u32) -> Result<(), i32> {
+    match chip_specific::esp_rom_spiflash_erase_sector(sector_number) {
+        0 => Ok(()),
+        value => Err(value),
+    }
+}
+
+/// Low-level SPI NOR Flash write
+///
+/// # Safety
+///
+/// The `dest_addr` + `len` should not exceeds the size of flash.
+/// The `data` expected to points to word-aligned buffer with size greater or equals to `len`.
+pub unsafe fn spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> Result<(), i32> {
+    match chip_specific::esp_rom_spiflash_write(dest_addr, data, len) {
+        0 => Ok(()),
+        value => Err(value),
+    }
+}

--- a/src/nor_flash.rs
+++ b/src/nor_flash.rs
@@ -1,0 +1,196 @@
+use crate::{FlashSectorBuffer, FlashStorage, FlashStorageError};
+use core::{
+    mem::MaybeUninit,
+    ops::{Deref, DerefMut},
+};
+use embedded_storage::nor_flash::{
+    ErrorType, NorFlash, NorFlashError, NorFlashErrorKind, ReadNorFlash,
+};
+
+#[repr(align(4))]
+struct FlashWordBuffer {
+    data: [u8; FlashStorage::WORD_SIZE as usize],
+}
+
+impl Deref for FlashWordBuffer {
+    type Target = [u8; FlashStorage::WORD_SIZE as usize];
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+impl DerefMut for FlashWordBuffer {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
+    }
+}
+
+impl FlashStorage {
+    #[inline(always)]
+    fn is_word_aligned(bytes: &[u8]) -> bool {
+        // TODO: Use is_aligned_to when stabilized (see `pointer_is_aligned`)
+        (unsafe { bytes.as_ptr().offset_from(core::ptr::null()) }) % Self::WORD_SIZE as isize == 0
+    }
+}
+
+impl NorFlashError for FlashStorageError {
+    fn kind(&self) -> NorFlashErrorKind {
+        match self {
+            Self::NotAligned => NorFlashErrorKind::NotAligned,
+            Self::OutOfBounds => NorFlashErrorKind::OutOfBounds,
+            _ => NorFlashErrorKind::Other,
+        }
+    }
+}
+
+impl ErrorType for FlashStorage {
+    type Error = FlashStorageError;
+}
+
+impl ReadNorFlash for FlashStorage {
+    #[cfg(not(feature = "bytewise-read"))]
+    const READ_SIZE: usize = Self::WORD_SIZE as _;
+
+    #[cfg(feature = "bytewise-read")]
+    const READ_SIZE: usize = 1;
+
+    fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+        self.check_alignment::<{ Self::READ_SIZE as _ }>(offset, bytes.len())?;
+        self.check_bounds(offset, bytes.len())?;
+
+        #[cfg(feature = "bytewise-read")]
+        let (offset, bytes) = {
+            let byte_offset = (offset % Self::WORD_SIZE) as usize;
+            if byte_offset > 0 {
+                let mut word_buffer = MaybeUninit::<FlashWordBuffer>::uninit();
+                let word_buffer = unsafe { word_buffer.assume_init_mut() };
+
+                let offset = offset - byte_offset as u32;
+                let length = bytes.len().min(word_buffer.len() - byte_offset);
+
+                self.internal_read(offset, &mut word_buffer[..])?;
+                bytes[..length].copy_from_slice(&word_buffer[byte_offset..][..length]);
+
+                (offset + Self::WORD_SIZE, &mut bytes[length..])
+            } else {
+                (offset, bytes)
+            }
+        };
+
+        if Self::is_word_aligned(bytes) {
+            // Bytes buffer is word-aligned so we can read directly to it
+            for (offset, chunk) in (offset..)
+                .step_by(Self::SECTOR_SIZE as _)
+                .zip(bytes.chunks_mut(Self::SECTOR_SIZE as _))
+            {
+                // Chunk already is word aligned so we can read directly to it
+                #[cfg(not(feature = "bytewise-read"))]
+                self.internal_read(offset, chunk)?;
+
+                #[cfg(feature = "bytewise-read")]
+                {
+                    let length = chunk.len();
+                    let byte_length = length % Self::WORD_SIZE as usize;
+                    let length = length - byte_length;
+
+                    self.internal_read(offset, &mut chunk[..length])?;
+
+                    // Read not aligned rest of data
+                    if byte_length > 0 {
+                        let mut word_buffer = MaybeUninit::<FlashWordBuffer>::uninit();
+                        let word_buffer = unsafe { word_buffer.assume_init_mut() };
+
+                        self.internal_read(offset + length as u32, &mut word_buffer[..])?;
+                        chunk[length..].copy_from_slice(&word_buffer[..byte_length]);
+                    }
+                }
+            }
+        } else {
+            // Bytes buffer isn't word-aligned so we might read only via aligned buffer
+            let mut buffer = MaybeUninit::<FlashSectorBuffer>::uninit();
+            let buffer = unsafe { buffer.assume_init_mut() };
+
+            for (offset, chunk) in (offset..)
+                .step_by(Self::SECTOR_SIZE as _)
+                .zip(bytes.chunks_mut(Self::SECTOR_SIZE as _))
+            {
+                // Read to temporary buffer first (chunk length is aligned)
+                #[cfg(not(feature = "bytewise-read"))]
+                self.internal_read(offset, &mut buffer[..chunk.len()])?;
+
+                // Read to temporary buffer first (chunk length is not aligned)
+                #[cfg(feature = "bytewise-read")]
+                {
+                    let length = chunk.len();
+                    let byte_length = length % Self::WORD_SIZE as usize;
+                    let length = if byte_length > 0 {
+                        length - byte_length + Self::WORD_SIZE as usize
+                    } else {
+                        length
+                    };
+
+                    self.internal_read(offset, &mut buffer[..length])?;
+                }
+
+                // Copy to bytes buffer
+                chunk.copy_from_slice(&buffer[..chunk.len()]);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn capacity(&self) -> usize {
+        self.capacity
+    }
+}
+
+impl NorFlash for FlashStorage {
+    const WRITE_SIZE: usize = Self::WORD_SIZE as _;
+    const ERASE_SIZE: usize = Self::SECTOR_SIZE as _;
+
+    fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+        self.check_alignment::<{ Self::WORD_SIZE }>(offset, bytes.len())?;
+        self.check_bounds(offset, bytes.len())?;
+
+        if Self::is_word_aligned(bytes) {
+            // Bytes buffer is word-aligned so we can write directly from it
+            for (offset, chunk) in (offset..)
+                .step_by(Self::SECTOR_SIZE as _)
+                .zip(bytes.chunks(Self::SECTOR_SIZE as _))
+            {
+                // Chunk already is word aligned so we can write directly from it
+                self.internal_write(offset, chunk)?;
+            }
+        } else {
+            // Bytes buffer isn't word-aligned so we might write only via aligned buffer
+            let mut buffer = MaybeUninit::<FlashSectorBuffer>::uninit();
+            let buffer = unsafe { buffer.assume_init_mut() };
+
+            for (offset, chunk) in (offset..)
+                .step_by(Self::SECTOR_SIZE as _)
+                .zip(bytes.chunks(Self::SECTOR_SIZE as _))
+            {
+                // Copy to temporary buffer first
+                buffer[..chunk.len()].copy_from_slice(chunk);
+                // Write from temporary buffer
+                self.internal_write(offset, &buffer[..chunk.len()])?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+        let len = (to - from) as _;
+        self.check_alignment::<{ Self::SECTOR_SIZE }>(from, len)?;
+        self.check_bounds(from, len)?;
+
+        for sector in from / Self::SECTOR_SIZE..to / Self::SECTOR_SIZE {
+            self.internal_erase(sector)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,71 @@
+use crate::{FlashSectorBuffer, FlashStorage, FlashStorageError};
+use core::mem::MaybeUninit;
+use embedded_storage::{ReadStorage, Storage};
+
+impl ReadStorage for FlashStorage {
+    type Error = FlashStorageError;
+
+    fn read(&mut self, offset: u32, mut bytes: &mut [u8]) -> Result<(), Self::Error> {
+        self.check_bounds(offset, bytes.len())?;
+
+        let mut data_offset = offset % Self::WORD_SIZE;
+        let mut aligned_offset = offset - data_offset;
+
+        // Bypass clearing sector buffer for performance reasons
+        let mut sector_data = MaybeUninit::<FlashSectorBuffer>::uninit();
+        let sector_data = unsafe { sector_data.assume_init_mut() };
+
+        while !bytes.is_empty() {
+            let len = bytes.len().min((Self::SECTOR_SIZE - data_offset) as _);
+
+            let aligned_end = (data_offset as usize + len + (Self::WORD_SIZE - 1) as usize)
+                & !(Self::WORD_SIZE - 1) as usize;
+
+            // Read only needed data words
+            self.internal_read(aligned_offset, &mut sector_data[..aligned_end])?;
+
+            bytes[..len].copy_from_slice(&sector_data[data_offset as usize..][..len]);
+
+            aligned_offset += Self::SECTOR_SIZE;
+            data_offset = 0;
+            bytes = &mut bytes[len..];
+        }
+
+        Ok(())
+    }
+
+    /// The SPI flash size is configured by writing a field in the software bootloader image header.
+    /// This is done during flashing in espflash / esptool.
+    fn capacity(&self) -> usize {
+        self.capacity
+    }
+}
+
+impl Storage for FlashStorage {
+    fn write(&mut self, offset: u32, mut bytes: &[u8]) -> Result<(), Self::Error> {
+        self.check_bounds(offset, bytes.len())?;
+
+        let mut data_offset = offset % Self::SECTOR_SIZE;
+        let mut aligned_offset = offset - data_offset;
+
+        // Bypass clearing sector buffer for performance reasons
+        let mut sector_data = MaybeUninit::<FlashSectorBuffer>::uninit();
+        let sector_data = unsafe { sector_data.assume_init_mut() };
+
+        while !bytes.is_empty() {
+            self.internal_read(aligned_offset, &mut sector_data[..])?;
+
+            let len = bytes.len().min((Self::SECTOR_SIZE - data_offset) as _);
+
+            sector_data[data_offset as usize..][..len].copy_from_slice(&bytes[..len]);
+            self.internal_erase(aligned_offset / Self::SECTOR_SIZE)?;
+            self.internal_write(aligned_offset, &sector_data[..])?;
+
+            aligned_offset += Self::SECTOR_SIZE;
+            data_offset = 0;
+            bytes = &bytes[len..];
+        }
+
+        Ok(())
+    }
+}

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -1,20 +1,111 @@
 use crate::maybe_with_critical_section;
+use core::{ptr, slice};
 
-#[cfg(not(doc))]
-compile_error!("Select a target using feature: esp32c2, esp32c3, esp32c6, esp32, esp32s2, esp32s3");
+#[cfg(not(any(doc, feature = "emulation")))]
+compile_error!(
+    "Select a target using feature: esp32c2, esp32c3, esp32c6, esp32h2, esp32, esp32s2, esp32s3"
+);
 
-pub(crate) fn esp_rom_spiflash_read(_src_addr: u32, _data: *const u32, _len: u32) -> i32 {
-    maybe_with_critical_section(|| unimplemented!())
+const SUCCESS_CODE: i32 = 0;
+const ERROR_CODE: i32 = 1;
+const ERASE_BYTE: u8 = 0xff;
+const WORD_SIZE: u32 = 4;
+const SECTOR_SIZE: u32 = 4 << 10;
+const NUM_SECTORS: u32 = 4;
+const FLASH_SIZE: u32 = SECTOR_SIZE * NUM_SECTORS;
+
+static mut FLASH_LOCK: bool = true;
+static mut FLASH_DATA: [u8; FLASH_SIZE as usize] = [0u8; FLASH_SIZE as usize];
+
+macro_rules! print_error {
+    ($($tt:tt)*) => {
+        #[cfg(all(test, feature = "emulation"))]
+        eprintln!($($tt)*)
+    };
+}
+
+fn check<const ALIGN: u32, const SIZE: u32, const MAX_LEN: u32>(
+    offset: u32,
+    length: u32,
+    data: *const u32,
+) -> bool {
+    if offset % ALIGN > 0 {
+        print_error!("Not aligned offset: {offset}");
+        return false;
+    }
+    if length % ALIGN > 0 {
+        print_error!("Not aligned length: {length}");
+        return false;
+    }
+    if offset > SIZE {
+        print_error!("Offset out of range: {offset} > {SIZE}");
+        return false;
+    }
+    if offset + length > SIZE {
+        print_error!("Length out of range: {offset} + {length} > {SIZE}");
+        return false;
+    }
+    if length > MAX_LEN {
+        print_error!("Length out of range: {length} > {MAX_LEN}");
+        return false;
+    }
+    let addr = unsafe { (data as *const u8).offset_from(ptr::null()) } as u32;
+    if addr % ALIGN > 0 {
+        print_error!("Not aligned data: {addr:#0x}");
+        return false;
+    }
+    if unsafe { FLASH_LOCK } {
+        print_error!("Flash locked");
+        return false;
+    }
+    true
+}
+
+pub(crate) fn esp_rom_spiflash_read(src_addr: u32, data: *mut u32, len: u32) -> i32 {
+    if check::<WORD_SIZE, FLASH_SIZE, SECTOR_SIZE>(src_addr, len, data) {
+        maybe_with_critical_section(|| {
+            let src = unsafe { slice::from_raw_parts_mut(data as *mut u8, len as _) };
+            unsafe { src.copy_from_slice(&FLASH_DATA[src_addr as usize..][..len as usize]) };
+        });
+        SUCCESS_CODE
+    } else {
+        ERROR_CODE
+    }
 }
 
 pub(crate) fn esp_rom_spiflash_unlock() -> i32 {
-    maybe_with_critical_section(|| unimplemented!())
+    maybe_with_critical_section(|| {
+        unsafe { FLASH_LOCK = false };
+    });
+    SUCCESS_CODE
 }
 
-pub(crate) fn esp_rom_spiflash_erase_sector(_sector_number: u32) -> i32 {
-    maybe_with_critical_section(|| unimplemented!())
+pub(crate) fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32 {
+    if check::<1, NUM_SECTORS, 1>(sector_number, 1, ptr::null()) {
+        maybe_with_critical_section(|| {
+            let dst_addr = sector_number * SECTOR_SIZE;
+            let len = SECTOR_SIZE;
+            unsafe { FLASH_DATA[dst_addr as usize..][..len as usize].fill(ERASE_BYTE) };
+        });
+        SUCCESS_CODE
+    } else {
+        ERROR_CODE
+    }
 }
 
-pub(crate) fn esp_rom_spiflash_write(_dest_addr: u32, _data: *const u32, _len: u32) -> i32 {
-    maybe_with_critical_section(|| unimplemented!())
+pub(crate) fn esp_rom_spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
+    if check::<WORD_SIZE, FLASH_SIZE, SECTOR_SIZE>(dest_addr, len, data) {
+        maybe_with_critical_section(|| {
+            let dst = unsafe { slice::from_raw_parts(data as *const u8, len as _) };
+            for (d, s) in unsafe { &mut FLASH_DATA[dest_addr as usize..][..len as usize] }
+                .iter_mut()
+                .zip(dst)
+            {
+                *d &= *s;
+            }
+        });
+        SUCCESS_CODE
+    } else {
+        ERROR_CODE
+    }
 }


### PR DESCRIPTION
The `nor-flash` feature adds impls of `ReadNoreFlash`/`NorFlash` traits from `embedded_storage::nor_flash`.
The `storage` feature adds impls of `ReadStorage`/`Storage` traits from `embedded_storage`. This feature is on by default for backward compatibility.

Needs some testing on hardware before to make it ready.

Related issue #12